### PR TITLE
fix: handle HttpException

### DIFF
--- a/src/error/errorHandler.ts
+++ b/src/error/errorHandler.ts
@@ -25,19 +25,13 @@ export class ErrorHandler implements ExceptionFilter {
     if (error instanceof AuthorizationError) {
       message = error.message;
       statusCode = HttpStatus.FORBIDDEN;
-    }
-
-    if (error instanceof NotFoundError) {
+    } else if (error instanceof NotFoundError) {
       message = error.message;
       statusCode = HttpStatus.NOT_FOUND;
-    }
-
-    if (error instanceof CRUDError) {
+    } else if (error instanceof CRUDError) {
       message = error.message;
       statusCode = HttpStatus.BAD_REQUEST;
-    }
-
-    if (error instanceof HttpException) {
+    } else if (error instanceof HttpException) {
       message = error.message;
       statusCode = error.getStatus();
     }

--- a/src/error/errorHandler.ts
+++ b/src/error/errorHandler.ts
@@ -19,23 +19,37 @@ export class ErrorHandler implements ExceptionFilter {
   }
 
   getResponseBody(error: unknown): { statusCode: HttpStatus; message: string } {
-    let message = 'INTERNAL_SERVER_ERROR';
-    let statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
-
     if (error instanceof AuthorizationError) {
-      message = error.message;
-      statusCode = HttpStatus.FORBIDDEN;
-    } else if (error instanceof NotFoundError) {
-      message = error.message;
-      statusCode = HttpStatus.NOT_FOUND;
-    } else if (error instanceof CRUDError) {
-      message = error.message;
-      statusCode = HttpStatus.BAD_REQUEST;
-    } else if (error instanceof HttpException) {
-      message = error.message;
-      statusCode = error.getStatus();
+      return {
+        message: error.message,
+        statusCode: HttpStatus.FORBIDDEN,
+      };
     }
 
-    return { statusCode, message };
+    if (error instanceof NotFoundError) {
+      return {
+        message: error.message,
+        statusCode: HttpStatus.NOT_FOUND,
+      };
+    }
+
+    if (error instanceof CRUDError) {
+      return {
+        message: error.message,
+        statusCode: HttpStatus.BAD_REQUEST,
+      };
+    }
+
+    if (error instanceof HttpException) {
+      return {
+        message: error.message,
+        statusCode: error.getStatus(),
+      };
+    }
+
+    return {
+      message: 'INTERNAL_SERVER_ERROR',
+      statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+    };
   }
 }

--- a/src/error/errorHandler.ts
+++ b/src/error/errorHandler.ts
@@ -1,4 +1,4 @@
-import { ExceptionFilter, Catch, ArgumentsHost, HttpStatus } from '@nestjs/common';
+import { ExceptionFilter, Catch, ArgumentsHost, HttpStatus, HttpException } from '@nestjs/common';
 import { HttpAdapterHost } from '@nestjs/core';
 import { AuthorizationError } from './authorization.error';
 import NotFoundError from './not-found.error';
@@ -35,6 +35,11 @@ export class ErrorHandler implements ExceptionFilter {
     if (error instanceof CRUDError) {
       message = error.message;
       statusCode = HttpStatus.BAD_REQUEST;
+    }
+
+    if (error instanceof HttpException) {
+      message = error.message;
+      statusCode = error.getStatus();
     }
 
     return { statusCode, message };


### PR DESCRIPTION
Right now global error handler throws `INTERNAL_SERVER_ERROR` for every unhandled error.
This PR changes the logic by adding the final guard which checks if the error is `HttpException` and throws it if that's true.
This prevents the situations when a proper `HttpException` is thrown on the higher level.